### PR TITLE
Bump type-fest from 2.19.0 to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,6 @@
 		"data-uri-to-buffer": "^4.0.0",
 		"follow-redirects": "^1.15.1",
 		"jsdom": "^20.0.0",
-		"type-fest": "^2.19.0"
+		"type-fest": "^3.0.0"
 	}
 }

--- a/src/violentmonkey-context.ts
+++ b/src/violentmonkey-context.ts
@@ -1,11 +1,12 @@
 // https://nodejs.org/api/async_context.html
 import {AsyncLocalStorage} from 'node:async_hooks';
 
+import type {EmptyObject} from 'type-fest';
+
 /* Ideally using empty arrays allows for garbage collection
 	in combination with (Better-)WeakMap
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-const asyncLocalStorage = new AsyncLocalStorage<[]>();
+const asyncLocalStorage = new AsyncLocalStorage<EmptyObject>();
 
 /* Abstract away AsyncLocalStorage#getStore to allow for error handling directly */
 
@@ -35,6 +36,6 @@ const getUserscriptId = () => {
 const violentMonkeyContext
 	= <Args extends any[], ReturnV>(cb: (...args: Args) => ReturnV) =>
 	(...args: Args) =>
-		asyncLocalStorage.run([], cb, ...args);
+		asyncLocalStorage.run({}, cb, ...args);
 
 export {violentMonkeyContext, getUserscriptId};

--- a/src/vm-storage.ts
+++ b/src/vm-storage.ts
@@ -1,10 +1,11 @@
+import type {EmptyObject} from 'type-fest';
+
 import {BetterWeakMap} from './utils/index.js';
 import {getUserscriptId} from './violentmonkey-context.js';
 
 /** @internal */
 class VMStorage<V> {
-	// eslint-disable-next-line @typescript-eslint/ban-types
-	private readonly storages = new BetterWeakMap<[], V>();
+	private readonly storages = new BetterWeakMap<EmptyObject, V>();
 
 	constructor(private readonly getDefaultValue: () => V) {}
 

--- a/test/violentmonkey-context.test.ts
+++ b/test/violentmonkey-context.test.ts
@@ -11,7 +11,7 @@ import {
 test(
 	'violentMonkeyContext should create a context with an id',
 	violentMonkeyContext(t => {
-		t.deepEqual(getUserscriptId(), []);
+		t.deepEqual(getUserscriptId(), {});
 	}),
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3290,10 +3290,15 @@ type-fest@^1.0.1, type-fest@^1.2.1, type-fest@^1.2.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
-type-fest@^2.0.0, type-fest@^2.19.0:
+type-fest@^2.0.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+
+type-fest@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.0.0.tgz#678e2e8d916e3b7dc1c3a6591d399ba3f7521584"
+  integrity sha512-MINvUN5ug9u+0hJDzSZNSnuKXI8M4F5Yvb6SQZ2CYqe7SgKXKOosEcU5R7tRgo85I6eAVBbkVF7TCvB4AUK2xQ==
 
 typescript@^4.7.3, typescript@^4.8.2:
   version "4.8.3"
@@ -3463,15 +3468,15 @@ xo@^0.52.2:
   integrity sha512-liCEteZ5z+QRyh3XzsYWQyxedBHBvx8CDlNvvi+BJz74L0E5/ID2v7JtoX3bD541AlMuOy4e/iWif6hhNGBFNw==
   dependencies:
     "@eslint/eslintrc" "^1.3.0"
-    "@typescript-eslint/eslint-plugin" "*"
-    "@typescript-eslint/parser" "*"
+    "@typescript-eslint/eslint-plugin" "^5.35.1"
+    "@typescript-eslint/parser" "^5.35.1"
     arrify "^3.0.0"
     cosmiconfig "^7.0.1"
     define-lazy-prop "^3.0.0"
     eslint "^8.22.0"
     eslint-config-prettier "^8.5.0"
     eslint-config-xo "^0.42.0"
-    eslint-config-xo-typescript "*"
+    eslint-config-xo-typescript "^0.53.0"
     eslint-formatter-pretty "^4.1.0"
     eslint-import-resolver-webpack "^0.13.2"
     eslint-plugin-ava "^13.2.0"


### PR DESCRIPTION
- Use EmptyObject for context id